### PR TITLE
ユーザータスクの作成

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,11 +2,17 @@ import { Module } from '@nestjs/common'
 import { SampleController } from './controller/sample/some-data.controller'
 import { UserController } from './controller/user/user.controller'
 import { TaskController } from './controller/task/task.controller'
+import { UserTaskController } from './controller/user-task/user-task.controller'
 
 // memo: DIコンテナとしては使わないため、controllerの追加だけしてください
 @Module({
   imports: [],
-  controllers: [SampleController, UserController, TaskController],
+  controllers: [
+    SampleController,
+    UserController,
+    TaskController,
+    UserTaskController,
+  ],
   providers: [],
 })
 export class AppModule {}

--- a/backend/src/app/__tests__/post-user-usecase.test.ts
+++ b/backend/src/app/__tests__/post-user-usecase.test.ts
@@ -1,23 +1,42 @@
 import { PrismaClient } from '@prisma/client'
 import { UserRepository } from 'src/infra/db/repository/user-repository'
 import { UserFactory } from 'src/domain/factory/user.factory'
+import { UserTaskRepository } from 'src/infra/db/repository/user-task-repository'
+import { UserTaskFactory } from 'src/domain/factory/user-task.factory'
+import { TaskQS } from 'src/infra/db/query-service/task-qs'
 import { PostUserUseCase } from '../post-user-usecase'
 import { mocked } from 'ts-jest/utils'
 import { MockedObjectDeep } from 'ts-jest/dist/utils/testing'
 
 jest.mock('@prisma/client')
 jest.mock('src/infra/db/repository/user-repository')
+jest.mock('src/domain/factory/user.factory')
+jest.mock('src/infra/db/repository/user-task-repository')
+jest.mock('src/domain/factory/user-task.factory')
+jest.mock('src/infra/db/query-service/task-qs')
 
 describe('do', () => {
   let mockUserRepo: MockedObjectDeep<UserRepository>
   let mockUserFac: MockedObjectDeep<UserFactory>
+  let mocktaskQS: MockedObjectDeep<TaskQS>
+  let mockUserTaskRepo: MockedObjectDeep<UserTaskRepository>
+  let mockUserTaskFac: MockedObjectDeep<UserTaskFactory>
   beforeAll(() => {
     const prisma = new PrismaClient()
     mockUserRepo = mocked(new UserRepository(prisma), true)
     mockUserFac = mocked(new UserFactory(mockUserRepo), true)
+    mocktaskQS = mocked(new TaskQS(prisma), true)
+    mockUserTaskRepo = mocked(new UserTaskRepository(prisma), true)
+    mockUserTaskFac = mocked(new UserTaskFactory(mockUserTaskRepo), true)
   })
   it('[正常系]: 例外が発生しない', async () => {
-    const usecase = new PostUserUseCase(mockUserRepo, mockUserFac)
+    const usecase = new PostUserUseCase(
+      mockUserRepo,
+      mockUserFac,
+      mocktaskQS,
+      mockUserTaskRepo,
+      mockUserTaskFac,
+    )
     return expect(
       usecase.do({
         name: '山田太郎',
@@ -28,7 +47,13 @@ describe('do', () => {
   it('[異常系]: UserRepository.saveで例外が発生した場合、例外が発生する', () => {
     const ERROR_MESSAGE = 'error!'
     mockUserRepo.save.mockRejectedValueOnce(ERROR_MESSAGE)
-    const usecase = new PostUserUseCase(mockUserRepo, mockUserFac)
+    const usecase = new PostUserUseCase(
+      mockUserRepo,
+      mockUserFac,
+      mocktaskQS,
+      mockUserTaskRepo,
+      mockUserTaskFac,
+    )
     return expect(
       usecase.do({
         name: '山田太郎',

--- a/backend/src/app/factory-interface/user-task-factory-interface.ts
+++ b/backend/src/app/factory-interface/user-task-factory-interface.ts
@@ -1,0 +1,22 @@
+import { UserTask } from 'src/domain/entity/user-task'
+import { Status } from 'src/domain/entity/sintyoku-status'
+
+type InsertUserTaskParams = {
+  kind: 'Insert'
+  id?: string
+  status: Status
+  userId: string
+  taskId: string
+}
+
+type UpdateUserTaskParams = {
+  kind: 'Update'
+  id: string
+  status: Status
+}
+
+export type UserTaskParams = InsertUserTaskParams | UpdateUserTaskParams
+
+export interface IUserTaskFactory {
+  create(params: UserTaskParams): Promise<UserTask>
+}

--- a/backend/src/app/factory-interface/user-task-factory-interface.ts
+++ b/backend/src/app/factory-interface/user-task-factory-interface.ts
@@ -3,8 +3,6 @@ import { Status } from 'src/domain/entity/sintyoku-status'
 
 type InsertUserTaskParams = {
   kind: 'Insert'
-  id?: string
-  status: Status
   userId: string
   taskId: string
 }

--- a/backend/src/app/get-users-usecase.ts
+++ b/backend/src/app/get-users-usecase.ts
@@ -1,20 +1,11 @@
 import { IUsersQS } from './query-service-interface/users-qs'
-import { Status } from 'src/domain/entity/sintyoku-status'
-
-type GetUserParams = {
-  taskIds?: string[]
-  status?: Status
-}
 export class GetUsersUseCase {
   private readonly userQS: IUsersQS
   public constructor(userQS: IUsersQS) {
     this.userQS = userQS
   }
-  public async do(params: GetUserParams) {
+  public async do() {
     try {
-      if (params.taskIds && params.status) {
-        return await this.userQS.search()
-      }
       return await this.userQS.getAll()
     } catch (error) {
       // memo: エラー処理

--- a/backend/src/app/get-users-usecase.ts
+++ b/backend/src/app/get-users-usecase.ts
@@ -1,12 +1,20 @@
 import { IUsersQS } from './query-service-interface/users-qs'
+import { Status } from 'src/domain/entity/sintyoku-status'
 
+type GetUserParams = {
+  taskIds?: string[]
+  status?: Status
+}
 export class GetUsersUseCase {
   private readonly userQS: IUsersQS
   public constructor(userQS: IUsersQS) {
     this.userQS = userQS
   }
-  public async do() {
+  public async do(params: GetUserParams) {
     try {
+      if (params.taskIds && params.status) {
+        return await this.userQS.search()
+      }
       return await this.userQS.getAll()
     } catch (error) {
       // memo: エラー処理

--- a/backend/src/app/post-user-usecase.ts
+++ b/backend/src/app/post-user-usecase.ts
@@ -30,7 +30,7 @@ export class PostUserUseCase {
     await this.userRepo.save(userEntity)
     //全てのタスクのユーザータスクの作成
     const allTasks = await this.taskQS.getAll()
-    allTasks.map(async (task) => {
+    await allTasks.map(async (task) => {
       const userTask = await this.userTaskFac.create({
         kind: 'Insert',
         userId: userEntity.getAllProperties().id,

--- a/backend/src/app/post-user-usecase.ts
+++ b/backend/src/app/post-user-usecase.ts
@@ -1,16 +1,42 @@
 import { IUserRepository } from './repository-interface/user-repository-interface'
 import { IUserFactory } from './factory-interface/user-factory-interface'
+import { ITaskQS } from './query-service-interface/task-qs'
+import { IUserTaskFactory } from './factory-interface/user-task-factory-interface'
+import { IUserTaskRepository } from './repository-interface/user-task-repository-interface'
 
 export class PostUserUseCase {
   private readonly userRepo: IUserRepository
   private readonly userFac: IUserFactory
-  public constructor(userRepo: IUserRepository, userFac: IUserFactory) {
+  private readonly taskQS: ITaskQS
+  private readonly userTaskRepo: IUserTaskRepository
+  private readonly userTaskFac: IUserTaskFactory
+
+  public constructor(
+    userRepo: IUserRepository,
+    userFac: IUserFactory,
+    taskQS: ITaskQS,
+    userTaskRepo: IUserTaskRepository,
+    userTaskFac: IUserTaskFactory,
+  ) {
     this.userRepo = userRepo
     this.userFac = userFac
+    this.taskQS = taskQS
+    this.userTaskRepo = userTaskRepo
+    this.userTaskFac = userTaskFac
   }
   public async do(params: { name: string; email: string }) {
     const { name, email } = params
     const userEntity = await this.userFac.create({ name, email })
     await this.userRepo.save(userEntity)
+    //全てのタスクのユーザータスクの作成
+    const allTasks = await this.taskQS.getAll()
+    allTasks.map(async (task) => {
+      const userTask = await this.userTaskFac.create({
+        kind: 'Insert',
+        userId: userEntity.getAllProperties().id,
+        taskId: task.id,
+      })
+      this.userTaskRepo.save(userTask)
+    })
   }
 }

--- a/backend/src/app/query-service-interface/users-qs.ts
+++ b/backend/src/app/query-service-interface/users-qs.ts
@@ -21,6 +21,7 @@ export class UserDTO {
 }
 
 export type SearchUserParams = {
+  page?: number
   taskIds?: string[]
   status?: SintyokuStatus
 }

--- a/backend/src/app/query-service-interface/users-qs.ts
+++ b/backend/src/app/query-service-interface/users-qs.ts
@@ -21,4 +21,5 @@ export class UserDTO {
 
 export interface IUsersQS {
   getAll(): Promise<UserDTO[]>
+  search(): Promise<UserDTO[]>
 }

--- a/backend/src/app/query-service-interface/users-qs.ts
+++ b/backend/src/app/query-service-interface/users-qs.ts
@@ -1,4 +1,5 @@
 import { Status } from 'src/domain/entity/zaiseki-status'
+import { Status as SintyokuStatus } from 'src/domain/entity/sintyoku-status'
 
 export class UserDTO {
   public readonly id: string
@@ -19,7 +20,11 @@ export class UserDTO {
   }
 }
 
+export type SearchUserParams = {
+  taskIds?: string[]
+  status?: SintyokuStatus
+}
 export interface IUsersQS {
   getAll(): Promise<UserDTO[]>
-  search(): Promise<UserDTO[]>
+  search(params: SearchUserParams): Promise<UserDTO[]>
 }

--- a/backend/src/app/repository-interface/user-task-repository-interface.ts
+++ b/backend/src/app/repository-interface/user-task-repository-interface.ts
@@ -1,0 +1,6 @@
+import { UserTask } from 'src/domain/entity/user-task'
+
+export interface IUserTaskRepository {
+  save(userTask: UserTask): Promise<UserTask>
+  find(id: String): Promise<UserTask>
+}

--- a/backend/src/app/search-user-usecase.ts
+++ b/backend/src/app/search-user-usecase.ts
@@ -1,0 +1,25 @@
+import { IUsersQS } from './query-service-interface/users-qs'
+import { Status } from 'src/domain/entity/sintyoku-status'
+
+type SearchUserByTaskParams = {
+  taskIds?: string[] | string
+  status?: Status
+}
+
+export class SearchUserUseCase {
+  private readonly userQS: IUsersQS
+  public constructor(userQS: IUsersQS) {
+    this.userQS = userQS
+  }
+  public async do(params: SearchUserByTaskParams) {
+    try {
+      if (typeof params.taskIds === 'string') {
+        params.taskIds = [params.taskIds]
+      }
+      return await this.userQS.search()
+    } catch (error) {
+      // memo: エラー処理
+      throw error
+    }
+  }
+}

--- a/backend/src/app/search-user-usecase.ts
+++ b/backend/src/app/search-user-usecase.ts
@@ -1,22 +1,30 @@
 import { IUsersQS } from './query-service-interface/users-qs'
 import { Status } from 'src/domain/entity/sintyoku-status'
 
-type SearchUserByTaskParams = {
+type SearchUserUseCaseParams = {
   taskIds?: string[] | string
   status?: Status
 }
-
 export class SearchUserUseCase {
   private readonly userQS: IUsersQS
   public constructor(userQS: IUsersQS) {
     this.userQS = userQS
   }
-  public async do(params: SearchUserByTaskParams) {
+  public async do(params: SearchUserUseCaseParams) {
     try {
+      let searchParams
       if (typeof params.taskIds === 'string') {
-        params.taskIds = [params.taskIds]
+        searchParams = {
+          taskIds: [params.taskIds],
+          status: params.status,
+        }
+      } else {
+        searchParams = {
+          taskIds: params.taskIds,
+          status: params.status,
+        }
       }
-      return await this.userQS.search()
+      return await this.userQS.search(searchParams)
     } catch (error) {
       // memo: エラー処理
       throw error

--- a/backend/src/app/search-user-usecase.ts
+++ b/backend/src/app/search-user-usecase.ts
@@ -2,6 +2,7 @@ import { IUsersQS } from './query-service-interface/users-qs'
 import { Status } from 'src/domain/entity/sintyoku-status'
 
 type SearchUserUseCaseParams = {
+  page?: number
   taskIds?: string[] | string
   status?: Status
 }
@@ -15,11 +16,13 @@ export class SearchUserUseCase {
       let searchParams
       if (typeof params.taskIds === 'string') {
         searchParams = {
+          page: params.page,
           taskIds: [params.taskIds],
           status: params.status,
         }
       } else {
         searchParams = {
+          page: params.page,
           taskIds: params.taskIds,
           status: params.status,
         }

--- a/backend/src/app/usecase/task/post-task-usecase.ts
+++ b/backend/src/app/usecase/task/post-task-usecase.ts
@@ -1,12 +1,27 @@
 import { ITaskRepository } from 'src/app/repository-interface/task-repository-interface'
 import { ITaskFactory } from 'src/app/factory-interface/task-factory-interface'
+import { IUsersQS } from 'src/app/query-service-interface/users-qs'
+import { IUserTaskFactory } from 'src/app/factory-interface/user-task-factory-interface'
+import { IUserTaskRepository } from 'src/app/repository-interface/user-task-repository-interface'
 
 export class PostTaskUseCase {
   private readonly taskRepo: ITaskRepository
   private readonly taskFac: ITaskFactory
-  public constructor(taskRepo: ITaskRepository, taskFac: ITaskFactory) {
+  private readonly userQS: IUsersQS
+  private readonly userTaskRepo: IUserTaskRepository
+  private readonly userTaskFac: IUserTaskFactory
+  public constructor(
+    taskRepo: ITaskRepository,
+    taskFac: ITaskFactory,
+    userQS: IUsersQS,
+    userTaskRepo: IUserTaskRepository,
+    userTaskFac: IUserTaskFactory,
+  ) {
     this.taskRepo = taskRepo
     this.taskFac = taskFac
+    this.userQS = userQS
+    this.userTaskRepo = userTaskRepo
+    this.userTaskFac = userTaskFac
   }
   public async do(params: {
     title: string
@@ -15,5 +30,15 @@ export class PostTaskUseCase {
   }) {
     const taskEntity = await this.taskFac.create(params)
     await this.taskRepo.save(taskEntity)
+    //全てのユーザーのユーザータスクの作成
+    const allUsers = await this.userQS.getAll()
+    allUsers.map(async (user) => {
+      const userTask = await this.userTaskFac.create({
+        kind: 'Insert',
+        userId: user.id,
+        taskId: taskEntity.getAllProperties().id,
+      })
+      this.userTaskRepo.save(userTask)
+    })
   }
 }

--- a/backend/src/app/usecase/task/post-task-usecase.ts
+++ b/backend/src/app/usecase/task/post-task-usecase.ts
@@ -32,7 +32,7 @@ export class PostTaskUseCase {
     await this.taskRepo.save(taskEntity)
     //全てのユーザーのユーザータスクの作成
     const allUsers = await this.userQS.getAll()
-    allUsers.map(async (user) => {
+    await allUsers.map(async (user) => {
       const userTask = await this.userTaskFac.create({
         kind: 'Insert',
         userId: user.id,

--- a/backend/src/app/usecase/user-task/update-user-task-usecase.ts
+++ b/backend/src/app/usecase/user-task/update-user-task-usecase.ts
@@ -1,0 +1,23 @@
+import { IUserTaskRepository } from 'src/app/repository-interface/user-task-repository-interface'
+import { IUserTaskFactory } from 'src/app/factory-interface/user-task-factory-interface'
+import { Status } from 'src/domain/entity/sintyoku-status'
+
+export class UpdateTaskUseCase {
+  private readonly userTaskRepo: IUserTaskRepository
+  private readonly userTaskFac: IUserTaskFactory
+  public constructor(
+    userTaskRepo: IUserTaskRepository,
+    userTaskFac: IUserTaskFactory,
+  ) {
+    this.userTaskRepo = userTaskRepo
+    this.userTaskFac = userTaskFac
+  }
+  public async do(params: { id: string; status: Status }) {
+    const userTaskEntity = await this.userTaskFac.create({
+      kind: 'Update',
+      id: params.id,
+      status: params.status,
+    })
+    await this.userTaskRepo.save(userTaskEntity)
+  }
+}

--- a/backend/src/app/usecase/user-task/update-user-task-usecase.ts
+++ b/backend/src/app/usecase/user-task/update-user-task-usecase.ts
@@ -2,7 +2,7 @@ import { IUserTaskRepository } from 'src/app/repository-interface/user-task-repo
 import { IUserTaskFactory } from 'src/app/factory-interface/user-task-factory-interface'
 import { Status } from 'src/domain/entity/sintyoku-status'
 
-export class UpdateTaskUseCase {
+export class UpdateUserTaskUseCase {
   private readonly userTaskRepo: IUserTaskRepository
   private readonly userTaskFac: IUserTaskFactory
   public constructor(

--- a/backend/src/controller/task/task.controller.ts
+++ b/backend/src/controller/task/task.controller.ts
@@ -11,6 +11,9 @@ import { PostTaskUseCase } from 'src/app/usecase/task/post-task-usecase'
 import { UpdateTaskUseCase } from 'src/app/usecase/task/update-task-usecase'
 import { UpdateTaskRequest } from './request/update-task-request'
 import { DeleteTaskUseCase } from 'src/app/usecase/task/delete-task-usecase'
+import { UserTaskRepository } from 'src/infra/db/repository/user-task-repository'
+import { UserTaskFactory } from 'src/domain/factory/user-task.factory'
+import { UsersQS } from 'src/infra/db/query-service/users-qs'
 
 @Controller({
   path: '/task',
@@ -32,7 +35,16 @@ export class TaskController {
     const prisma = new PrismaClient()
     const repo = new TaskRepository(prisma)
     const factory = new TaskFactory(repo)
-    const usecase = new PostTaskUseCase(repo, factory)
+    const usersQS = new UsersQS(prisma)
+    const userTaskRepo = new UserTaskRepository(prisma)
+    const userTaskFac = new UserTaskFactory(userTaskRepo)
+    const usecase = new PostTaskUseCase(
+      repo,
+      factory,
+      usersQS,
+      userTaskRepo,
+      userTaskFac,
+    )
     await usecase.do({
       title: postTaskDto.title,
       reason: postTaskDto.reason,

--- a/backend/src/controller/user-task/request/update-user-task-request.ts
+++ b/backend/src/controller/user-task/request/update-user-task-request.ts
@@ -1,0 +1,15 @@
+// @see https://docs.nestjs.com/openapi/types-and-parameters
+
+import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty } from 'class-validator'
+import { Status } from 'src/domain/entity/sintyoku-status'
+
+export class UpdateUserTaskRequest {
+  @ApiProperty()
+  // @IsNotEmpty()
+  readonly userId: string | undefined
+
+  @ApiProperty()
+  @IsNotEmpty()
+  readonly status!: Status
+}

--- a/backend/src/controller/user-task/user-task.controller.ts
+++ b/backend/src/controller/user-task/user-task.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Post, Param } from '@nestjs/common'
+import { ApiResponse } from '@nestjs/swagger'
+import { PrismaClient } from '@prisma/client'
+import { UserTaskRepository } from 'src/infra/db/repository/user-task-repository'
+import { UserTaskFactory } from 'src/domain/factory/user-task.factory'
+import { UpdateUserTaskUseCase } from 'src/app/usecase/user-task/update-user-task-usecase'
+import { UpdateUserTaskRequest } from './request/update-user-task-request'
+
+@Controller({
+  path: '/user-task',
+})
+export class UserTaskController {
+  @Post(':id')
+  async updateUser(
+    @Param('id') id: string,
+    @Body() updateUserTaskDto: UpdateUserTaskRequest,
+  ): Promise<void> {
+    const prisma = new PrismaClient()
+    const repo = new UserTaskRepository(prisma)
+    const factory = new UserTaskFactory(repo)
+    const usecase = new UpdateUserTaskUseCase(repo, factory)
+    await usecase.do({
+      id,
+      status: updateUserTaskDto.status,
+    })
+  }
+}

--- a/backend/src/controller/user/request/search-user-query.ts
+++ b/backend/src/controller/user/request/search-user-query.ts
@@ -1,0 +1,12 @@
+// @see https://docs.nestjs.com/openapi/types-and-parameters
+
+import { ApiProperty } from '@nestjs/swagger'
+import { Status } from 'src/domain/entity/sintyoku-status'
+
+export class SearchUserQuery {
+  @ApiProperty()
+  readonly taskIds: string[] | undefined
+
+  @ApiProperty()
+  readonly status: Status | undefined
+}

--- a/backend/src/controller/user/request/search-user-query.ts
+++ b/backend/src/controller/user/request/search-user-query.ts
@@ -5,7 +5,7 @@ import { Status } from 'src/domain/entity/sintyoku-status'
 
 export class SearchUserQuery {
   @ApiProperty()
-  readonly taskIds: string[] | undefined
+  readonly taskIds: string[] | string | undefined
 
   @ApiProperty()
   readonly status: Status | undefined

--- a/backend/src/controller/user/request/search-user-query.ts
+++ b/backend/src/controller/user/request/search-user-query.ts
@@ -5,6 +5,9 @@ import { Status } from 'src/domain/entity/sintyoku-status'
 
 export class SearchUserQuery {
   @ApiProperty()
+  readonly page: number | undefined
+
+  @ApiProperty()
   readonly taskIds: string[] | string | undefined
 
   @ApiProperty()

--- a/backend/src/controller/user/user.controller.ts
+++ b/backend/src/controller/user/user.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Post, Param, Delete } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Param,
+  Delete,
+  Query,
+} from '@nestjs/common'
 import { ApiResponse } from '@nestjs/swagger'
 import { PostUserRequest } from './request/post-user-request'
 import { PrismaClient } from '@prisma/client'
@@ -10,6 +18,7 @@ import { UserFactory } from 'src/domain/factory/user.factory'
 import { PostUserUseCase } from 'src/app/post-user-usecase'
 import { UpdateUserUseCase } from 'src/app/update-user-usecase'
 import { UpdateUserRequest } from './request/update-user-request'
+import { SearchUserQuery } from './request/search-user-query'
 import { DeleteUserUseCase } from 'src/app/delete-user-usecase'
 import { UserTaskRepository } from 'src/infra/db/repository/user-task-repository'
 import { UserTaskFactory } from 'src/domain/factory/user-task.factory'
@@ -22,11 +31,14 @@ export class UserController {
   // memo: @ApiResponseを定義しておかないとSwaggerに出力されない
   @Get()
   @ApiResponse({ status: 200, type: GetUsersResponse })
-  async getUsers(): Promise<GetUsersResponse> {
+  async getUsers(
+    @Query() searchUserQuery: SearchUserQuery,
+  ): Promise<GetUsersResponse> {
+    console.log('searchUserQuery', searchUserQuery)
     const prisma = new PrismaClient()
     const qs = new UsersQS(prisma)
     const usecase = new GetUsersUseCase(qs)
-    const result = await usecase.do()
+    const result = await usecase.do(searchUserQuery)
     const response = new GetUsersResponse({ users: result })
     return response
   }

--- a/backend/src/controller/user/user.controller.ts
+++ b/backend/src/controller/user/user.controller.ts
@@ -13,6 +13,7 @@ import { PrismaClient } from '@prisma/client'
 import { GetUsersResponse } from './response/get-users-response'
 import { UsersQS } from 'src/infra/db/query-service/users-qs'
 import { GetUsersUseCase } from '../../app/get-users-usecase'
+import { SearchUserUseCase } from '../../app/search-user-usecase'
 import { UserRepository } from 'src/infra/db/repository/user-repository'
 import { UserFactory } from 'src/domain/factory/user.factory'
 import { PostUserUseCase } from 'src/app/post-user-usecase'
@@ -31,13 +32,22 @@ export class UserController {
   // memo: @ApiResponseを定義しておかないとSwaggerに出力されない
   @Get()
   @ApiResponse({ status: 200, type: GetUsersResponse })
-  async getUsers(
-    @Query() searchUserQuery: SearchUserQuery,
-  ): Promise<GetUsersResponse> {
-    console.log('searchUserQuery', searchUserQuery)
+  async getUsers(): Promise<GetUsersResponse> {
     const prisma = new PrismaClient()
     const qs = new UsersQS(prisma)
     const usecase = new GetUsersUseCase(qs)
+    const result = await usecase.do()
+    const response = new GetUsersResponse({ users: result })
+    return response
+  }
+  @Get('/search')
+  @ApiResponse({ status: 200, type: GetUsersResponse })
+  async searchUser(
+    @Query() searchUserQuery: SearchUserQuery,
+  ): Promise<GetUsersResponse> {
+    const prisma = new PrismaClient()
+    const qs = new UsersQS(prisma)
+    const usecase = new SearchUserUseCase(qs)
     const result = await usecase.do(searchUserQuery)
     const response = new GetUsersResponse({ users: result })
     return response

--- a/backend/src/controller/user/user.controller.ts
+++ b/backend/src/controller/user/user.controller.ts
@@ -11,6 +11,9 @@ import { PostUserUseCase } from 'src/app/post-user-usecase'
 import { UpdateUserUseCase } from 'src/app/update-user-usecase'
 import { UpdateUserRequest } from './request/update-user-request'
 import { DeleteUserUseCase } from 'src/app/delete-user-usecase'
+import { UserTaskRepository } from 'src/infra/db/repository/user-task-repository'
+import { UserTaskFactory } from 'src/domain/factory/user-task.factory'
+import { TaskQS } from 'src/infra/db/query-service/task-qs'
 
 @Controller({
   path: '/user',
@@ -32,7 +35,16 @@ export class UserController {
     const prisma = new PrismaClient()
     const repo = new UserRepository(prisma)
     const factory = new UserFactory(repo)
-    const usecase = new PostUserUseCase(repo, factory)
+    const taskQS = new TaskQS(prisma)
+    const userTaskRepo = new UserTaskRepository(prisma)
+    const userTaskFac = new UserTaskFactory(userTaskRepo)
+    const usecase = new PostUserUseCase(
+      repo,
+      factory,
+      taskQS,
+      userTaskRepo,
+      userTaskFac,
+    )
     await usecase.do({
       name: postUserDto.name,
       email: postUserDto.email,

--- a/backend/src/domain/__tests__/user-task.entity.test.ts
+++ b/backend/src/domain/__tests__/user-task.entity.test.ts
@@ -1,0 +1,18 @@
+import { UserTask } from 'src/domain/entity/user-task'
+import { Status } from 'src/domain/entity/sintyoku-status'
+import { createRandomIdString } from 'src/util/random'
+
+describe('user-task.entity.test', () => {
+  describe('getAllProperties', () => {
+    it('[正常系]作成したインスタンスのプロパティが全て取れる', () => {
+      const userTaskExpected = {
+        id: createRandomIdString(),
+        status: 'NotStarted' as Status,
+        userId: createRandomIdString(),
+        taskId: createRandomIdString(),
+      }
+      const userTask = new UserTask(userTaskExpected)
+      expect(userTask.getAllProperties()).toEqual(userTaskExpected)
+    })
+  })
+})

--- a/backend/src/domain/entity/sintyoku-status.ts
+++ b/backend/src/domain/entity/sintyoku-status.ts
@@ -1,0 +1,1 @@
+export type Status = 'NotStarted' | 'InReview' | 'Completed'

--- a/backend/src/domain/entity/user-task.ts
+++ b/backend/src/domain/entity/user-task.ts
@@ -1,0 +1,28 @@
+import { Status } from './sintyoku-status'
+
+export class UserTask {
+  private id: string
+  public readonly status: Status
+  public readonly userId: string
+  public readonly taskId: string
+  public constructor(props: {
+    id: string
+    status: Status
+    userId: string
+    taskId: string
+  }) {
+    const { id, status, userId, taskId } = props
+    this.id = id
+    this.status = status ?? 'NotStarted'
+    this.userId = userId
+    this.taskId = taskId
+  }
+  public getAllProperties() {
+    return {
+      id: this.id,
+      status: this.status,
+      userId: this.userId,
+      taskId: this.taskId,
+    }
+  }
+}

--- a/backend/src/domain/entity/user-task.ts
+++ b/backend/src/domain/entity/user-task.ts
@@ -7,7 +7,7 @@ export class UserTask {
   public readonly taskId: string
   public constructor(props: {
     id: string
-    status: Status
+    status?: Status
     userId: string
     taskId: string
   }) {

--- a/backend/src/domain/factory/user-task.factory.ts
+++ b/backend/src/domain/factory/user-task.factory.ts
@@ -1,0 +1,32 @@
+import {
+  IUserTaskFactory,
+  UserTaskParams,
+} from 'src/app/factory-interface/user-task-factory-interface'
+import { IUserTaskRepository } from 'src/app/repository-interface/user-task-repository-interface'
+import { UserTask } from 'src/domain/entity/user-task'
+import { createRandomIdString } from 'src/util/random'
+
+export class UserTaskFactory implements IUserTaskFactory {
+  private userTaskRepo: IUserTaskRepository
+  public constructor(userTaskRepo: IUserTaskRepository) {
+    this.userTaskRepo = userTaskRepo
+  }
+  public async create(params: UserTaskParams): Promise<UserTask> {
+    if (params.kind === 'Update') {
+      const beforeUserTask = await this.userTaskRepo.find(params.id)
+      const updateUserTaskParams = {
+        id: params.id,
+        status: params.status,
+        userId: beforeUserTask.userId,
+        taskId: beforeUserTask.taskId,
+      }
+      return new UserTask(updateUserTaskParams)
+    } else {
+      return new UserTask({
+        id: createRandomIdString(),
+        userId: params.userId,
+        taskId: params.taskId,
+      })
+    }
+  }
+}

--- a/backend/src/infra/db/__tests__/task-repository.integration.test.ts
+++ b/backend/src/infra/db/__tests__/task-repository.integration.test.ts
@@ -6,6 +6,7 @@ import { TaskRepository } from '../repository/task-repository'
 describe('task-repository.integration.ts', () => {
   const taskRepo = new TaskRepository(prisma)
   beforeAll(async () => {
+    //TODOここのあたりでテストが落ちるので直すおそらくDBの関係
     await prisma.task.deleteMany({})
   })
   afterAll(async () => {
@@ -24,9 +25,12 @@ describe('task-repository.integration.ts', () => {
       }
       await taskRepo.save(new Task(taskExpected))
 
-      const allTasks = await prisma.task.findMany({})
-      expect(allTasks).toHaveLength(1)
-      expect(allTasks[0]).toEqual(taskExpected)
+      const createdTask = await prisma.task.findUnique({
+        where: {
+          id: taskExpected.id,
+        },
+      })
+      expect(createdTask).toEqual(taskExpected)
     })
     it('[正常系]taskを更新できる', async () => {
       const creatingTask = {
@@ -37,8 +41,11 @@ describe('task-repository.integration.ts', () => {
       }
       await taskRepo.save(new Task(creatingTask))
 
-      const createTasks = await prisma.task.findMany({})
-      const createdTask = createTasks[0]
+      const createdTask = await prisma.task.findUnique({
+        where: {
+          id: creatingTask.id,
+        },
+      })
       const id = createdTask?.id ?? ''
       const taskExpected = {
         id: id,
@@ -48,9 +55,12 @@ describe('task-repository.integration.ts', () => {
         description: 'DDDについて、ペアに説明してみましょう。テスト更新。',
       }
       await taskRepo.save(new Task(taskExpected))
-      const allTasks = await prisma.task.findMany({})
-      expect(allTasks).toHaveLength(1)
-      expect(allTasks[0]).toEqual(taskExpected)
+      const updatedTask = await prisma.task.findUnique({
+        where: {
+          id: taskExpected.id,
+        },
+      })
+      expect(updatedTask).toEqual(taskExpected)
     })
   })
   describe('delete', () => {
@@ -66,8 +76,12 @@ describe('task-repository.integration.ts', () => {
       }
       await taskRepo.save(new Task(creatingTask))
       await taskRepo.delete(creatingTask.id)
-      const allTasks = await prisma.task.findMany({})
-      expect(allTasks).toHaveLength(0)
+      const deletedTask = await prisma.task.findUnique({
+        where: {
+          id: creatingTask.id,
+        },
+      })
+      expect(deletedTask).toEqual(null)
     })
   })
 })

--- a/backend/src/infra/db/__tests__/user-task-repository.integration.test.ts
+++ b/backend/src/infra/db/__tests__/user-task-repository.integration.test.ts
@@ -1,0 +1,92 @@
+// import { UserTask } from 'src/domain/entity/user-task'
+// import { Status } from 'src/domain/entity/sintyoku-status'
+// import { User } from 'src/domain/entity/user'
+// import { Status as ZaisekiStatus } from 'src/domain/entity/zaiseki-status'
+// import { Task } from 'src/domain/entity/task'
+// import { createRandomIdString } from 'src/util/random'
+// import { prisma } from '@testUtil/prisma'
+// import { UserTaskRepository } from '../repository/user-task-repository'
+// import { UserRepository } from '../repository/user-repository'
+// import { TaskRepository } from '../repository/task-repository'
+
+describe('user-task-repository.integration.ts', () => {
+  //TODO テストの順番が保証されずに、こっちでもtaskやuserのデータ作られて、エラーになる。対策検討中。
+  // const userTaskRepo = new UserTaskRepository(prisma)
+  // const userRepo = new UserRepository(prisma)
+  // const taskRepo = new TaskRepository(prisma)
+  // beforeAll(async () => {
+  //   await prisma.user.deleteMany({})
+  //   await prisma.task.deleteMany({})
+  //   await prisma.userTask.deleteMany({})
+  // })
+  // afterAll(async () => {
+  //   await prisma.$disconnect()
+  // })
+  // describe('save', () => {
+  //   afterEach(async () => {
+  //     await prisma.user.deleteMany({})
+  //   })
+  //   it('[正常系]userTaskを保存できる', async () => {
+  //     const userExpected = {
+  //       id: createRandomIdString(),
+  //       name: '山田太郎',
+  //       email: 'test@test.com',
+  //       //TODOここasつけなきゃなのか深堀したい
+  //       status: 'Inmembership' as ZaisekiStatus,
+  //     }
+  //     const taskExpected = {
+  //       id: createRandomIdString(),
+  //       title: 'DDDを学ぶ',
+  //       reason: 'アプリケーションの設計・保守性について考える力を養うため。',
+  //       description: 'DDDについて、ペアに説明してみましょう。',
+  //     }
+  //     await userRepo.save(new User(userExpected))
+  //     await taskRepo.save(new Task(taskExpected))
+  //     const userTaskExpected = {
+  //       id: createRandomIdString(),
+  //       status: 'NotStarted' as Status,
+  //       userId: userExpected.id,
+  //       taskId: taskExpected.id,
+  //     }
+  //     await userTaskRepo.save(new UserTask(userTaskExpected))
+  //     const allUserTasks = await prisma.userTask.findMany({})
+  //     expect(allUserTasks).toHaveLength(1)
+  //     expect(allUserTasks[0]).toEqual(userTaskExpected)
+  //   })
+  //   it('[正常系]userTaskを更新できる', async () => {
+  //     //TODOこの辺2回書いてるからどうにかしてまとめたい
+  //     const userExpected = {
+  //       id: createRandomIdString(),
+  //       name: '山田太郎',
+  //       email: 'test@test.com',
+  //       //TODOここasつけなきゃなのか深堀したい
+  //       status: 'Inmembership' as ZaisekiStatus,
+  //     }
+  //     const taskExpected = {
+  //       id: createRandomIdString(),
+  //       title: 'DDDを学ぶ',
+  //       reason: 'アプリケーションの設計・保守性について考える力を養うため。',
+  //       description: 'DDDについて、ペアに説明してみましょう。',
+  //     }
+  //     await userRepo.save(new User(userExpected))
+  //     await taskRepo.save(new Task(taskExpected))
+  //     const createTaskExpected = {
+  //       id: createRandomIdString(),
+  //       status: 'NotStarted' as Status,
+  //       userId: userExpected.id,
+  //       taskId: taskExpected.id,
+  //     }
+  //     const userTaskExpected = {
+  //       id: createTaskExpected?.id,
+  //       status: 'Inactive' as Status,
+  //       userId: userExpected.id,
+  //       taskId: taskExpected.id,
+  //     }
+  //     await userTaskRepo.save(new UserTask(createTaskExpected))
+  //     await userTaskRepo.save(new UserTask(userTaskExpected))
+  //     const allUserTasks = await prisma.userTask.findMany({})
+  //     expect(allUserTasks).toHaveLength(1)
+  //     expect(allUserTasks[0]).toEqual(userTaskExpected)
+  //   })
+  // })
+})

--- a/backend/src/infra/db/__tests__/user-task-repository.integration.test.ts
+++ b/backend/src/infra/db/__tests__/user-task-repository.integration.test.ts
@@ -1,92 +1,100 @@
-// import { UserTask } from 'src/domain/entity/user-task'
-// import { Status } from 'src/domain/entity/sintyoku-status'
-// import { User } from 'src/domain/entity/user'
-// import { Status as ZaisekiStatus } from 'src/domain/entity/zaiseki-status'
-// import { Task } from 'src/domain/entity/task'
-// import { createRandomIdString } from 'src/util/random'
-// import { prisma } from '@testUtil/prisma'
-// import { UserTaskRepository } from '../repository/user-task-repository'
-// import { UserRepository } from '../repository/user-repository'
-// import { TaskRepository } from '../repository/task-repository'
+import { UserTask } from 'src/domain/entity/user-task'
+import { Status } from 'src/domain/entity/sintyoku-status'
+import { User } from 'src/domain/entity/user'
+import { Status as ZaisekiStatus } from 'src/domain/entity/zaiseki-status'
+import { Task } from 'src/domain/entity/task'
+import { createRandomIdString } from 'src/util/random'
+import { prisma } from '@testUtil/prisma'
+import { UserTaskRepository } from '../repository/user-task-repository'
+import { UserRepository } from '../repository/user-repository'
+import { TaskRepository } from '../repository/task-repository'
+import { createUserTestData } from '../../../../testUtil/user-data-factory'
 
 describe('user-task-repository.integration.ts', () => {
-  //TODO テストの順番が保証されずに、こっちでもtaskやuserのデータ作られて、エラーになる。対策検討中。
-  // const userTaskRepo = new UserTaskRepository(prisma)
-  // const userRepo = new UserRepository(prisma)
-  // const taskRepo = new TaskRepository(prisma)
-  // beforeAll(async () => {
-  //   await prisma.user.deleteMany({})
-  //   await prisma.task.deleteMany({})
-  //   await prisma.userTask.deleteMany({})
-  // })
-  // afterAll(async () => {
-  //   await prisma.$disconnect()
-  // })
-  // describe('save', () => {
-  //   afterEach(async () => {
-  //     await prisma.user.deleteMany({})
-  //   })
-  //   it('[正常系]userTaskを保存できる', async () => {
-  //     const userExpected = {
-  //       id: createRandomIdString(),
-  //       name: '山田太郎',
-  //       email: 'test@test.com',
-  //       //TODOここasつけなきゃなのか深堀したい
-  //       status: 'Inmembership' as ZaisekiStatus,
-  //     }
-  //     const taskExpected = {
-  //       id: createRandomIdString(),
-  //       title: 'DDDを学ぶ',
-  //       reason: 'アプリケーションの設計・保守性について考える力を養うため。',
-  //       description: 'DDDについて、ペアに説明してみましょう。',
-  //     }
-  //     await userRepo.save(new User(userExpected))
-  //     await taskRepo.save(new Task(taskExpected))
-  //     const userTaskExpected = {
-  //       id: createRandomIdString(),
-  //       status: 'NotStarted' as Status,
-  //       userId: userExpected.id,
-  //       taskId: taskExpected.id,
-  //     }
-  //     await userTaskRepo.save(new UserTask(userTaskExpected))
-  //     const allUserTasks = await prisma.userTask.findMany({})
-  //     expect(allUserTasks).toHaveLength(1)
-  //     expect(allUserTasks[0]).toEqual(userTaskExpected)
-  //   })
-  //   it('[正常系]userTaskを更新できる', async () => {
-  //     //TODOこの辺2回書いてるからどうにかしてまとめたい
-  //     const userExpected = {
-  //       id: createRandomIdString(),
-  //       name: '山田太郎',
-  //       email: 'test@test.com',
-  //       //TODOここasつけなきゃなのか深堀したい
-  //       status: 'Inmembership' as ZaisekiStatus,
-  //     }
-  //     const taskExpected = {
-  //       id: createRandomIdString(),
-  //       title: 'DDDを学ぶ',
-  //       reason: 'アプリケーションの設計・保守性について考える力を養うため。',
-  //       description: 'DDDについて、ペアに説明してみましょう。',
-  //     }
-  //     await userRepo.save(new User(userExpected))
-  //     await taskRepo.save(new Task(taskExpected))
-  //     const createTaskExpected = {
-  //       id: createRandomIdString(),
-  //       status: 'NotStarted' as Status,
-  //       userId: userExpected.id,
-  //       taskId: taskExpected.id,
-  //     }
-  //     const userTaskExpected = {
-  //       id: createTaskExpected?.id,
-  //       status: 'Inactive' as Status,
-  //       userId: userExpected.id,
-  //       taskId: taskExpected.id,
-  //     }
-  //     await userTaskRepo.save(new UserTask(createTaskExpected))
-  //     await userTaskRepo.save(new UserTask(userTaskExpected))
-  //     const allUserTasks = await prisma.userTask.findMany({})
-  //     expect(allUserTasks).toHaveLength(1)
-  //     expect(allUserTasks[0]).toEqual(userTaskExpected)
-  //   })
-  // })
+  const userTaskRepo = new UserTaskRepository(prisma)
+  const userRepo = new UserRepository(prisma)
+  const taskRepo = new TaskRepository(prisma)
+  beforeAll(async () => {
+    //TODOここのあたりでテストが落ちるので直すおそらくDBの関係
+    await prisma.user.deleteMany({})
+    await prisma.task.deleteMany({})
+    await prisma.userTask.deleteMany({})
+  })
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+  describe('save', () => {
+    afterEach(async () => {
+      await prisma.user.deleteMany({})
+    })
+    it('[正常系]userTaskを保存できる', async () => {
+      const randomUser = createUserTestData()
+      const userExpected = {
+        id: randomUser.id,
+        name: randomUser.name,
+        email: randomUser.email,
+        //TODOここasつけなきゃなのか深堀したい
+        status: 'Inmembership' as ZaisekiStatus,
+      }
+      const taskExpected = {
+        id: createRandomIdString(),
+        title: 'DDDを学ぶ',
+        reason: 'アプリケーションの設計・保守性について考える力を養うため。',
+        description: 'DDDについて、ペアに説明してみましょう。',
+      }
+      await userRepo.save(new User(userExpected))
+      await taskRepo.save(new Task(taskExpected))
+      const userTaskExpected = {
+        id: createRandomIdString(),
+        status: 'NotStarted' as Status,
+        userId: userExpected.id,
+        taskId: taskExpected.id,
+      }
+      await userTaskRepo.save(new UserTask(userTaskExpected))
+      const userTask = await prisma.userTask.findUnique({
+        where: {
+          id: userTaskExpected.id,
+        },
+      })
+      expect(userTask).toEqual(userTaskExpected)
+    })
+    it('[正常系]userTaskを更新できる', async () => {
+      const randomUser = createUserTestData()
+      const userExpected = {
+        id: randomUser.id,
+        name: randomUser.name,
+        email: randomUser.email,
+        //TODOここasつけなきゃなのか深堀したい
+        status: 'Inmembership' as ZaisekiStatus,
+      }
+      const taskExpected = {
+        id: createRandomIdString(),
+        title: 'DDDを学ぶ',
+        reason: 'アプリケーションの設計・保守性について考える力を養うため。',
+        description: 'DDDについて、ペアに説明してみましょう。',
+      }
+      await userRepo.save(new User(userExpected))
+      await taskRepo.save(new Task(taskExpected))
+      const createTaskExpected = {
+        id: createRandomIdString(),
+        status: 'NotStarted' as Status,
+        userId: userExpected.id,
+        taskId: taskExpected.id,
+      }
+      const userTaskExpected = {
+        id: createTaskExpected?.id,
+        status: 'InReview' as Status,
+        userId: userExpected.id,
+        taskId: taskExpected.id,
+      }
+      await userTaskRepo.save(new UserTask(createTaskExpected))
+      await userTaskRepo.save(new UserTask(userTaskExpected))
+      const userTask = await prisma.userTask.findUnique({
+        where: {
+          id: userTaskExpected.id,
+        },
+      })
+      expect(userTask).toEqual(userTaskExpected)
+    })
+  })
 })

--- a/backend/src/infra/db/query-service/users-qs.ts
+++ b/backend/src/infra/db/query-service/users-qs.ts
@@ -23,9 +23,11 @@ export class UsersQS implements IUsersQS {
   public async search(params: SearchUserParams): Promise<UserDTO[]> {
     let seachedUsers
     if (
+      typeof params.page !== undefined &&
       typeof params.taskIds !== undefined &&
       typeof params.status !== undefined
     ) {
+      const page = params.page ?? 1
       const searchCondtions = params.taskIds?.map((taskId) => {
         return {
           UserTask: {
@@ -38,6 +40,8 @@ export class UsersQS implements IUsersQS {
         where: {
           OR: searchCondtions,
         },
+        skip: (page - 1) * 10,
+        take: 10,
       })
     } else {
       seachedUsers = await this.prismaClient.user.findMany({})

--- a/backend/src/infra/db/query-service/users-qs.ts
+++ b/backend/src/infra/db/query-service/users-qs.ts
@@ -16,4 +16,20 @@ export class UsersQS implements IUsersQS {
         }),
     )
   }
+  public async search(): Promise<UserDTO[]> {
+    const seachedUsers = await this.prismaClient.user.findMany({
+      include: {
+        UserTask: true,
+      },
+    })
+    console.log('seachedUsers', seachedUsers)
+    return seachedUsers.map((user) => {
+      return new UserDTO({
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        status: user.status,
+      })
+    })
+  }
 }

--- a/backend/src/infra/db/query-service/users-qs.ts
+++ b/backend/src/infra/db/query-service/users-qs.ts
@@ -33,6 +33,7 @@ export class UsersQS implements IUsersQS {
           },
         }
       })
+      //https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#relation-filters
       seachedUsers = await this.prismaClient.user.findMany({
         where: {
           OR: searchCondtions,

--- a/backend/src/infra/db/repository/user-task-repository.ts
+++ b/backend/src/infra/db/repository/user-task-repository.ts
@@ -1,0 +1,47 @@
+import { PrismaClient } from '@prisma/client'
+import { IUserTaskRepository } from 'src/app/repository-interface/user-task-repository-interface'
+import { UserTask } from 'src/domain/entity/user-task'
+
+export class UserTaskRepository implements IUserTaskRepository {
+  private prismaClient: PrismaClient
+  public constructor(prismaClient: PrismaClient) {
+    this.prismaClient = prismaClient
+  }
+  public async save(userTaskEntity: UserTask): Promise<UserTask> {
+    const {
+      id,
+      status,
+      userId,
+      taskId,
+    } = await userTaskEntity.getAllProperties()
+
+    const savedUserTaskModel = await this.prismaClient.userTask.upsert({
+      where: {
+        id,
+      },
+      create: {
+        id,
+        status,
+        userId,
+        taskId,
+      },
+      update: {
+        status,
+      },
+    })
+    const savedUserTaskEntity = new UserTask({ ...savedUserTaskModel })
+    return savedUserTaskEntity
+  }
+  public async find(id: string): Promise<UserTask> {
+    const findedUserTaskModel = await this.prismaClient.userTask.findFirst({
+      where: {
+        id,
+      },
+    })
+    if (!findedUserTaskModel) {
+      throw new Error('ユーザータスクは見つかりませんでした。')
+    }
+    const findedUserTaskEntity = new UserTask({ ...findedUserTaskModel })
+    return findedUserTaskEntity
+  }
+}

--- a/backend/testUtil/user-data-factory.ts
+++ b/backend/testUtil/user-data-factory.ts
@@ -1,0 +1,13 @@
+import * as faker from 'faker'
+type RandomUser = {
+  id: string
+  name: string
+  email: string
+}
+export const createUserTestData = (): RandomUser => {
+  return {
+    id: faker.random.uuid(),
+    name: `${faker.name.lastName()} ${faker.name.firstName()}`,
+    email: faker.internet.email(),
+  }
+}


### PR DESCRIPTION
## やったこと

1. ユーザータスクの更新
2. ユーザーが作られたときにユーザータスクの作成される
3. タスクが作成された時にユーザータスクも作成される
4. あるタスクの進捗状況でユーザーを検索できるようにする

## まだ残っているところ

- [ ] ユーザー、タスクの削除時にユーザータスクを削除
- [ ] テストの修正
- [ ] 上記に伴い、DBの設定変更
- [ ] 4の時のレスポンスの変更（タスクの名前やタスクの進捗も出したい）
- [ ] ユーザーじゃないと更新されないように