### PR TITLE
ユーザーが増えたときのチームペアを増やす減らすのロジック(1)

### DIFF
--- a/backend/src/app/repository-interface/team-repository-interface.ts
+++ b/backend/src/app/repository-interface/team-repository-interface.ts
@@ -2,5 +2,5 @@ import { Team } from 'src/domain/entity/Team'
 
 export interface ITeamRepository {
   save(team: Team): Promise<Team>
-  findByUserId(userId: string): Promise<Team>
+  getByNameLast(): Promise<Team>
 }

--- a/backend/src/app/repository-interface/team-repository-interface.ts
+++ b/backend/src/app/repository-interface/team-repository-interface.ts
@@ -2,7 +2,7 @@ import { Team } from 'src/domain/entity/Team'
 
 export interface ITeamRepository {
   save(team: Team): Promise<Team>
-  getTeamNameByNameLast(): Promise<string | null>
+  getLastTeamName(): Promise<string | null>
   getMinimumMemberTeam(): Promise<Team | null>
   getAllTeam(): Promise<Team[]>
 }

--- a/backend/src/app/repository-interface/team-repository-interface.ts
+++ b/backend/src/app/repository-interface/team-repository-interface.ts
@@ -2,5 +2,5 @@ import { Team } from 'src/domain/entity/Team'
 
 export interface ITeamRepository {
   save(team: Team): Promise<Team>
-  getByNameLast(): Promise<Team>
+  getByNameLast(): Promise<Team | null>
 }

--- a/backend/src/app/repository-interface/team-repository-interface.ts
+++ b/backend/src/app/repository-interface/team-repository-interface.ts
@@ -4,4 +4,5 @@ export interface ITeamRepository {
   save(team: Team): Promise<Team>
   getTeamNameByNameLast(): Promise<string | null>
   getMinimumMemberTeam(): Promise<Team | null>
+  getAllTeam(): Promise<Team[]>
 }

--- a/backend/src/app/repository-interface/team-repository-interface.ts
+++ b/backend/src/app/repository-interface/team-repository-interface.ts
@@ -2,5 +2,5 @@ import { Team } from 'src/domain/entity/Team'
 
 export interface ITeamRepository {
   save(team: Team): Promise<Team>
-  getByNameLast(): Promise<string | null>
+  getTeamNameByNameLast(): Promise<string | null>
 }

--- a/backend/src/app/repository-interface/team-repository-interface.ts
+++ b/backend/src/app/repository-interface/team-repository-interface.ts
@@ -3,4 +3,5 @@ import { Team } from 'src/domain/entity/Team'
 export interface ITeamRepository {
   save(team: Team): Promise<Team>
   getTeamNameByNameLast(): Promise<string | null>
+  getMinimumMemberTeam(): Promise<Team | null>
 }

--- a/backend/src/app/repository-interface/team-repository-interface.ts
+++ b/backend/src/app/repository-interface/team-repository-interface.ts
@@ -2,5 +2,5 @@ import { Team } from 'src/domain/entity/Team'
 
 export interface ITeamRepository {
   save(team: Team): Promise<Team>
-  getByNameLast(): Promise<Team | null>
+  getByNameLast(): Promise<string | null>
 }

--- a/backend/src/domain/entity/team.ts
+++ b/backend/src/domain/entity/team.ts
@@ -52,6 +52,13 @@ export class Team {
     }
     return result
   }
+  public getTeamMemberCount() {
+    return this.pairs.reduce(
+      (previousValue, currentValue) =>
+        previousValue + currentValue.membersCount,
+      0,
+    )
+  }
 }
 
 export class Pair {

--- a/backend/src/domain/entity/team.ts
+++ b/backend/src/domain/entity/team.ts
@@ -59,6 +59,13 @@ export class Team {
       0,
     )
   }
+  public getMinimuMemberPair() {
+    return this.pairs.reduce((previousValue, currentValue) =>
+      previousValue.membersCount > currentValue.membersCount
+        ? previousValue
+        : currentValue,
+    )
+  }
 }
 
 export class Pair {

--- a/backend/src/domain/entity/team.ts
+++ b/backend/src/domain/entity/team.ts
@@ -119,26 +119,38 @@ export class Pair {
   }
 }
 
-export class Member extends User {
-  private pairMemberId: string
-  constructor(props: {
-    id: string
-    name: string
-    email: string
-    status?: Status
-    pairMemberId: string
-  }) {
-    const { id, name, email, status, pairMemberId } = props
-    super({ id, name, email, status })
-    this.pairMemberId = pairMemberId
+// export class Member extends User {
+//   private pairMemberId: string
+//   constructor(props: {
+//     id: string
+//     name: string
+//     email: string
+//     status?: Status
+//     pairMemberId: string
+//   }) {
+//     const { id, name, email, status, pairMemberId } = props
+//     super({ id, name, email, status })
+//     this.pairMemberId = pairMemberId
+//   }
+//   getAllProperties() {
+//     return {
+//       id: this.id,
+//       name: this.name,
+//       email: this.email,
+//       status: this.status,
+//       pairMemberId: this.pairMemberId,
+//     }
+//   }
+// }
+
+export class Member {
+  private id: string
+  constructor(props: { id: string }) {
+    this.id = props.id
   }
   getAllProperties() {
     return {
       id: this.id,
-      name: this.name,
-      email: this.email,
-      status: this.status,
-      pairMemberId: this.pairMemberId,
     }
   }
 }

--- a/backend/src/domain/service/team.service.ts
+++ b/backend/src/domain/service/team.service.ts
@@ -8,7 +8,7 @@ export class TeamService {
   }
   //数字順でつけられるチーム名の次のやつを取得
   public async getNewTeamName() {
-    const lastTeamName = await this.teamRepo.getTeamNameByNameLast()
+    const lastTeamName = await this.teamRepo.getLastTeamName()
     const newTeamName = lastTeamName
       ? (Number(lastTeamName) + 1).toString()
       : '1'

--- a/backend/src/domain/service/team.service.ts
+++ b/backend/src/domain/service/team.service.ts
@@ -5,4 +5,10 @@ export class TeamService {
   public constructor(teamRepo: ITeamRepository) {
     this.teamRepo = teamRepo
   }
+  //数字順でつけられるチーム名の次のやつを取得
+  public async getNewTeamName() {
+    const lastTeam = await this.teamRepo.getByNameLast()
+    const newTeamName = (Number(lastTeam.name) + 1).toString()
+    return newTeamName
+  }
 }

--- a/backend/src/domain/service/team.service.ts
+++ b/backend/src/domain/service/team.service.ts
@@ -8,7 +8,9 @@ export class TeamService {
   //数字順でつけられるチーム名の次のやつを取得
   public async getNewTeamName() {
     const lastTeam = await this.teamRepo.getByNameLast()
-    const newTeamName = (Number(lastTeam.name) + 1).toString()
+    const newTeamName = lastTeam?.name
+      ? (Number(lastTeam.name) + 1).toString()
+      : '1'
     return newTeamName
   }
 }

--- a/backend/src/domain/service/team.service.ts
+++ b/backend/src/domain/service/team.service.ts
@@ -1,4 +1,5 @@
 import { ITeamRepository } from 'src/app/repository-interface/team-repository-interface'
+import { Team } from 'src/domain/entity/team'
 
 export class TeamService {
   private teamRepo: ITeamRepository
@@ -12,5 +13,16 @@ export class TeamService {
       ? (Number(lastTeamName) + 1).toString()
       : '1'
     return newTeamName
+  }
+  //一番メンバー数が少ないチームを返す(本当はrepoでやりたい)
+  public async getMinimumMemberTeam(): Promise<Team | null> {
+    const allTeams = await this.teamRepo.getAllTeam()
+    const minimumMemberTeam = allTeams.reduce((previousValue, currentValue) =>
+      //同じの場合はpreviousを大きいとする
+      previousValue.getTeamMemberCount > currentValue.getTeamMemberCount
+        ? previousValue
+        : currentValue,
+    )
+    return minimumMemberTeam
   }
 }

--- a/backend/src/domain/service/team.service.ts
+++ b/backend/src/domain/service/team.service.ts
@@ -7,9 +7,9 @@ export class TeamService {
   }
   //数字順でつけられるチーム名の次のやつを取得
   public async getNewTeamName() {
-    const lastTeam = await this.teamRepo.getByNameLast()
-    const newTeamName = lastTeam?.name
-      ? (Number(lastTeam.name) + 1).toString()
+    const lastTeamName = await this.teamRepo.getTeamNameByNameLast()
+    const newTeamName = lastTeamName
+      ? (Number(lastTeamName) + 1).toString()
       : '1'
     return newTeamName
   }

--- a/backend/src/infra/db/repository/team-repository.ts
+++ b/backend/src/infra/db/repository/team-repository.ts
@@ -88,7 +88,7 @@ export class TeamRepository implements ITeamRepository {
     })
   }
 
-  public async getTeamNameByNameLast(): Promise<string | null> {
+  public async getLastTeamName(): Promise<string | null> {
     const gettedTeam = await this.prismaClient.team.findFirst({
       orderBy: { name: 'desc' },
       select: {

--- a/backend/src/infra/db/repository/team-repository.ts
+++ b/backend/src/infra/db/repository/team-repository.ts
@@ -100,4 +100,23 @@ export class TeamRepository implements ITeamRepository {
     }
     return gettedTeam.name
   }
+  public async getMinimumMemberTeam(): Promise<Team | null> {
+    const gettedTeam = await this.prismaClient.team.findMany({
+      include: {
+        TeamPair: {
+          include: {
+            pair: {
+              include: {
+                PairMember: true,
+                _count: {
+                  select: { PairMember: true },
+                },
+              },
+            },
+          },
+        },
+      },
+      //TODOのorderbyのやり方
+    })
+  }
 }

--- a/backend/src/infra/db/repository/team-repository.ts
+++ b/backend/src/infra/db/repository/team-repository.ts
@@ -25,53 +25,66 @@ export class TeamRepository implements ITeamRepository {
     })
 
     //teamPairテーブルとpairテーブル、 pairMemberテーブルに対するupsert
-    const savedPairList = pairs.map(async (pair) => {
-      const savedTeamPair = await this.prismaClient.teamPair.upsert({
-        where: {
-          id: pair.getAllProperties().teamPairId,
-        },
-        create: {
-          id: pair.getAllProperties().teamPairId,
-          teamId: id,
-          pairId: pair.getAllProperties().id,
-        },
-        update: {
-          teamId: id,
-          pairId: pair.getAllProperties().id,
-        },
-      })
-      const savedPair = await this.prismaClient.pair.upsert({
-        where: {
-          id: pair.getAllProperties().id,
-        },
-        create: {
-          id: pair.getAllProperties().id,
-          name: pair.getAllProperties().name,
-        },
-        update: {
-          name: pair.getAllProperties().name,
-        },
-      })
-      //pairMemberテーブルの更新
-      const savedMamberList = await Promise.all(
-        pair.members.map(async (member) => {
-          const savedMamber = await this.prismaClient.pairMember.upsert({
-            where: {
-              id: member.getAllProperties().id,
-            },
-            create: {
-              id: member.getAllProperties().id,
-              pairId: pair.getAllProperties().id,
-              userId: member.getAllProperties().id,
-            },
-            update: {
-              pairId: pair.getAllProperties().id,
-              userId: member.getAllProperties().id,
-            },
-          })
-          return new Member({ id: savedMamber.id })
-        }),
-      )
+    const savedPairList = await Promise.all(
+      pairs.map(async (pair) => {
+        const savedTeamPair = await this.prismaClient.teamPair.upsert({
+          where: {
+            id: pair.getAllProperties().teamPairId,
+          },
+          create: {
+            id: pair.getAllProperties().teamPairId,
+            teamId: id,
+            pairId: pair.getAllProperties().id,
+          },
+          update: {
+            teamId: id,
+            pairId: pair.getAllProperties().id,
+          },
+        })
+        const savedPair = await this.prismaClient.pair.upsert({
+          where: {
+            id: pair.getAllProperties().id,
+          },
+          create: {
+            id: pair.getAllProperties().id,
+            name: pair.getAllProperties().name,
+          },
+          update: {
+            name: pair.getAllProperties().name,
+          },
+        })
+        //pairMemberテーブルの更新
+        const savedMamberList = await Promise.all(
+          pair.members.map(async (member) => {
+            const savedMamber = await this.prismaClient.pairMember.upsert({
+              where: {
+                id: member.getAllProperties().id,
+              },
+              create: {
+                id: member.getAllProperties().id,
+                pairId: pair.getAllProperties().id,
+                userId: member.getAllProperties().id,
+              },
+              update: {
+                pairId: pair.getAllProperties().id,
+                userId: member.getAllProperties().id,
+              },
+            })
+            return new Member({ id: savedMamber.id })
+          }),
+        )
+        return new Pair({
+          id: savedPair.id,
+          name: savedPair.name,
+          members: savedMamberList,
+          teamPairId: savedTeamPair.id,
+        })
+      }),
+    )
+    return new Team({
+      id: savedTeam.id,
+      name: savedTeam.name,
+      pairs: savedPairList,
     })
   }
 

--- a/backend/src/infra/db/repository/team-repository.ts
+++ b/backend/src/infra/db/repository/team-repository.ts
@@ -88,7 +88,7 @@ export class TeamRepository implements ITeamRepository {
     })
   }
 
-  public async getByNameLast(): Promise<Team> {
+  public async getByNameLast(): Promise<Team | null> {
     const gettedTeam = await this.prismaClient.team.findFirst({
       orderBy: { name: 'desc' },
       include: {
@@ -96,7 +96,7 @@ export class TeamRepository implements ITeamRepository {
       },
     })
     if (!gettedTeam) {
-      throw new Error('チームは見つかりませんでした。')
+      return null
     }
     const pairsEntity = gettedTeam.TeamPair.map((teamPair) => {
       const membersEntity = teamPair.pair.PairMember.map((pairMember) => {

--- a/backend/src/infra/db/repository/team-repository.ts
+++ b/backend/src/infra/db/repository/team-repository.ts
@@ -88,31 +88,16 @@ export class TeamRepository implements ITeamRepository {
     })
   }
 
-  public async getByNameLast(): Promise<Team | null> {
+  public async getTeamNameByNameLast(): Promise<string | null> {
     const gettedTeam = await this.prismaClient.team.findFirst({
       orderBy: { name: 'desc' },
-      include: {
-        TeamPair: { include: { pair: { include: { PairMember: true } } } },
+      select: {
+        name: true,
       },
     })
     if (!gettedTeam) {
       return null
     }
-    const pairsEntity = gettedTeam.TeamPair.map((teamPair) => {
-      const membersEntity = teamPair.pair.PairMember.map((pairMember) => {
-        return new Member({ id: pairMember.id })
-      })
-      return new Pair({
-        id: teamPair.pair.id,
-        name: teamPair.pair.name,
-        teamPairId: teamPair.id,
-        members: membersEntity,
-      })
-    })
-    return new Team({
-      id: gettedTeam.id,
-      name: gettedTeam.name,
-      pairs: pairsEntity,
-    })
+    return gettedTeam.name
   }
 }


### PR DESCRIPTION
## やった実装

1. teamのsaveがうまくできてなかったので続きの修正
2. 最も参加人数が少ないチームを選ぶ処理
3. 最も参加人数が少ないペアを選ぶ処理
4. チーム名数字順でつけられるがその数字を算出する処理